### PR TITLE
Fix a bug of beam index.

### DIFF
--- a/src/hlds_laser_publisher.cpp
+++ b/src/hlds_laser_publisher.cpp
@@ -107,7 +107,7 @@ void LFCDLaser::poll(sensor_msgs::LaserScan::Ptr scan)
 
             for(uint16_t j = i+4; j < i+40; j=j+6)
             {
-              index = (6*i)/42 + (j-6-i)/6;
+              index = 6*(i/42) + (j-4-i)/6;  // 6*(i/42): beam num of the previous sets, (j-4-i)/6: beam num in the current set
 
               // Four bytes per reading
               uint8_t byte0 = raw_bytes[j];


### PR DESCRIPTION
Fixed calculation of beam indexes. In the old code, the indexes were wrongly shifted by one.

- Results of the old code: [0, 0, 1, ..., 358].
- Results of the new code: [0, 1, 2, ..., 359].
