### PR TITLE
Modify to stop motor in LFCDLaser d'tor.

### DIFF
--- a/include/hls_lfcd_lds_driver/lfcd_laser.h
+++ b/include/hls_lfcd_lds_driver/lfcd_laser.h
@@ -48,7 +48,7 @@ public:
 	* @param baud_rate The baud rate to open the serial port at.
 	* @param io Boost ASIO IO Service to use when creating the serial port object
 	*/
-	LFCDLaser(const std::string& port, uint32_t baud_rate, uint32_t lfcdstartstop, boost::asio::io_service& io);
+	LFCDLaser(const std::string& port, uint32_t baud_rate, boost::asio::io_service& io);
 
 	/**
 	* @brief Default destructor
@@ -69,7 +69,6 @@ public:
 private:
 	std::string port_; ///< @brief The serial port the driver is attached to
 	uint32_t baud_rate_; ///< @brief The baud rate for the serial connection
-	uint32_t lfcdstartstop_; ///< @brief The LDS Start/Stop to check.
 	bool shutting_down_; ///< @brief Flag for whether the driver is supposed to be shutting down or not
 	boost::asio::serial_port serial_; ///< @brief Actual serial port object for reading/writing to the LFCD Laser Scanner
 	uint16_t motor_speed_; ///< @brief current motor speed as reported by the LFCD.

--- a/include/hls_lfcd_lds_driver/lfcd_laser.h
+++ b/include/hls_lfcd_lds_driver/lfcd_laser.h
@@ -40,8 +40,8 @@ namespace hls_lfcd_lds
 {
 class LFCDLaser
 {
- public:
-  uint16_t rpms; ///< @brief RPMS derived from the rpm bytes in an LFCD packet
+public:
+	uint16_t rpms; ///< @brief RPMS derived from the rpm bytes in an LFCD packet
 	/**
 	* @brief Constructs a new LFCDLaser attached to the given serial port
 	* @param port The string for the serial port device to attempt to connect to, e.g. "/dev/ttyUSB0"
@@ -64,14 +64,14 @@ class LFCDLaser
 	/**
 	* @brief Close the driver down and prevent the polling loop from advancing
 	*/
-	void close() { shutting_down_ = true; };
+	void close() { shutting_down_ = true; }
 
- private:
-  std::string port_; ///< @brief The serial port the driver is attached to
+private:
+	std::string port_; ///< @brief The serial port the driver is attached to
 	uint32_t baud_rate_; ///< @brief The baud rate for the serial connection
 	uint32_t lfcdstartstop_; ///< @brief The LDS Start/Stop to check.
 	bool shutting_down_; ///< @brief Flag for whether the driver is supposed to be shutting down or not
 	boost::asio::serial_port serial_; ///< @brief Actual serial port object for reading/writing to the LFCD Laser Scanner
 	uint16_t motor_speed_; ///< @brief current motor speed as reported by the LFCD.
 };
-};
+}

--- a/include/hls_lfcd_lds_driver/lfcd_laser.h
+++ b/include/hls_lfcd_lds_driver/lfcd_laser.h
@@ -53,7 +53,7 @@ class LFCDLaser
 	/**
 	* @brief Default destructor
 	*/
-	~LFCDLaser() {};
+	~LFCDLaser();
 
 	/**
 	* @brief Poll the laser to get a new scan. Blocks until a complete new scan is received or close is called.

--- a/src/hlds_laser_publisher.cpp
+++ b/src/hlds_laser_publisher.cpp
@@ -142,7 +142,7 @@ void LFCDLaser::poll(sensor_msgs::LaserScan::Ptr scan)
     }
   }
 }
-};
+}
 
 int main(int argc, char **argv)
 {

--- a/src/hlds_laser_publisher.cpp
+++ b/src/hlds_laser_publisher.cpp
@@ -39,19 +39,12 @@
 
 namespace hls_lfcd_lds
 {
-LFCDLaser::LFCDLaser(const std::string& port, uint32_t baud_rate, uint32_t lfcdstartstop, boost::asio::io_service& io): port_(port),
-baud_rate_(baud_rate), lfcdstartstop_(lfcdstartstop), shutting_down_(false), serial_(io, port_)
+LFCDLaser::LFCDLaser(const std::string& port, uint32_t baud_rate, boost::asio::io_service& io)
+  : port_(port), baud_rate_(baud_rate), shutting_down_(false), serial_(io, port_)
 {
   serial_.set_option(boost::asio::serial_port_base::baud_rate(baud_rate_));
 
-  if(lfcdstartstop_ == 1)
-  {
-    boost::asio::write(serial_, boost::asio::buffer("b", 1));
-  }
-  else if(lfcdstartstop_ == 2)
-  {
-    boost::asio::write(serial_, boost::asio::buffer("e", 1));
-  }
+  boost::asio::write(serial_, boost::asio::buffer("b", 1));  // start motor
 }
 
 LFCDLaser::~LFCDLaser()
@@ -153,22 +146,18 @@ int main(int argc, char **argv)
   std::string port;
   int baud_rate;
   std::string frame_id;
-  int lfcdstart;
-  int lfcdstop;
 
   std_msgs::UInt16 rpms;
 
   priv_nh.param("port", port, std::string("/dev/ttyUSB0"));
   priv_nh.param("baud_rate", baud_rate, 230400);
   priv_nh.param("frame_id", frame_id, std::string("laser"));
-  priv_nh.param("lfcd_start", lfcdstart, 1);
-  priv_nh.param("lfcd_stop", lfcdstop, 2);
 
   boost::asio::io_service io;
 
   try
   {
-    hls_lfcd_lds::LFCDLaser laser(port, baud_rate, lfcdstart, io);
+    hls_lfcd_lds::LFCDLaser laser(port, baud_rate, io);
     ros::Publisher laser_pub = n.advertise<sensor_msgs::LaserScan>("scan", 1000);
     ros::Publisher motor_pub = n.advertise<std_msgs::UInt16>("rpms",1000);
 
@@ -188,8 +177,7 @@ int main(int argc, char **argv)
   }
   catch (boost::system::system_error ex)
   {
-    hls_lfcd_lds::LFCDLaser laser(port, baud_rate, lfcdstop, io);
-    ROS_ERROR("Error instantiating laser object. Are you sure you have the correct port and baud rate? Error was %s", ex.what());
+    ROS_ERROR("An exception was thrown: %s", ex.what());
     return -1;
   }
 }

--- a/src/hlds_laser_publisher.cpp
+++ b/src/hlds_laser_publisher.cpp
@@ -54,6 +54,11 @@ baud_rate_(baud_rate), lfcdstartstop_(lfcdstartstop), shutting_down_(false), ser
   }
 }
 
+LFCDLaser::~LFCDLaser()
+{
+  boost::asio::write(serial_, boost::asio::buffer("e", 1));  // stop motor
+}
+
 void LFCDLaser::poll(sensor_msgs::LaserScan::Ptr scan)
 {
   uint8_t temp_char;


### PR DESCRIPTION
- The motor should stop in d'tor. Deleted unused lfcdstartstop arg.
- An exception will be thrown by Ctrl-c. Therefore, fixed an exception error message.
