### PR TITLE
 chronological order and full rpm set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(hls_lfcd_lds_driver)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
+  message_generation
 )
 
 find_package(Boost REQUIRED COMPONENTS system)
@@ -17,7 +18,14 @@ find_package(Boost REQUIRED COMPONENTS system)
 ################################################################################
 # Declare ROS messages, services and actions
 ################################################################################
-
+add_message_files(
+  FILES
+  rpms_msg.msg
+)
+ generate_messages(
+   DEPENDENCIES
+   std_msgs
+)
 ################################################################################
 ## Declare ROS dynamic reconfigure parameters
 ################################################################################
@@ -28,7 +36,7 @@ find_package(Boost REQUIRED COMPONENTS system)
 catkin_package(
    INCLUDE_DIRS include
    LIBRARIES hls_lfcd_lds_driver
-   CATKIN_DEPENDS roscpp sensor_msgs
+   CATKIN_DEPENDS roscpp sensor_msgs message_runtime
 )
 
 ################################################################################

--- a/include/hls_lfcd_lds_driver/lfcd_laser.h
+++ b/include/hls_lfcd_lds_driver/lfcd_laser.h
@@ -35,6 +35,7 @@
 #include <boost/asio.hpp>
 #include <boost/array.hpp>
 #include <string>
+#include <vector>
 
 namespace hls_lfcd_lds
 {
@@ -42,13 +43,14 @@ class LFCDLaser
 {
 public:
 	uint16_t rpms; ///< @brief RPMS derived from the rpm bytes in an LFCD packet
+	std::vector<uint16_t> v_rpms;
 	/**
 	* @brief Constructs a new LFCDLaser attached to the given serial port
 	* @param port The string for the serial port device to attempt to connect to, e.g. "/dev/ttyUSB0"
 	* @param baud_rate The baud rate to open the serial port at.
 	* @param io Boost ASIO IO Service to use when creating the serial port object
 	*/
-	LFCDLaser(const std::string& port, uint32_t baud_rate, boost::asio::io_service& io);
+	LFCDLaser(const std::string& port, uint32_t baud_rate, boost::asio::io_service& io, bool chron_ord);
 
 	/**
 	* @brief Default destructor
@@ -66,11 +68,14 @@ public:
 	*/
 	void close() { shutting_down_ = true; }
 
+	typedef float& (*ScandataPlacer)(std::vector<float>&,size_t);
+	ScandataPlacer scandataPlacer=NULL;
 private:
 	std::string port_; ///< @brief The serial port the driver is attached to
 	uint32_t baud_rate_; ///< @brief The baud rate for the serial connection
 	bool shutting_down_; ///< @brief Flag for whether the driver is supposed to be shutting down or not
 	boost::asio::serial_port serial_; ///< @brief Actual serial port object for reading/writing to the LFCD Laser Scanner
 	uint16_t motor_speed_; ///< @brief current motor speed as reported by the LFCD.
+	bool chron_ord;
 };
 }

--- a/msg/rpms_msg.msg
+++ b/msg/rpms_msg.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+uint16[] rpms

--- a/package.xml
+++ b/package.xml
@@ -18,8 +18,10 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
   <run_depend>boost</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
   <export></export>
 </package>


### PR DESCRIPTION
-odometry-based unwarping may simply assume chronological order of the
range data
-the full rpm set can be used by the unwarping function to improve the
angular accuracy