### PR TITLE
Fix build warnings in ROS2 Dashing

### DIFF
--- a/src/hlds_laser_publisher.cpp
+++ b/src/hlds_laser_publisher.cpp
@@ -152,8 +152,8 @@ int main(int argc, char **argv)
 
   try
   {
-    hls_lfcd_lds::LFCDLaser laser(port, baud_rate, io);   
-    laser_pub = node->create_publisher<sensor_msgs::msg::LaserScan>("scan");
+    hls_lfcd_lds::LFCDLaser laser(port, baud_rate, io);
+    laser_pub = node->create_publisher<sensor_msgs::msg::LaserScan>("scan", rclcpp::QoS(10));
 
     while (rclcpp::ok())
     {
@@ -164,7 +164,7 @@ int main(int argc, char **argv)
       rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
       ts.attachClock(clock);
       scan->header.stamp = clock->now();
-      laser_pub->publish(scan);
+      laser_pub->publish(*scan);
     }
     laser.close();
 


### PR DESCRIPTION
This change fixes the two warnings below in ROS2 dashing. It is a breaking change for the Crystal release, however.

Perhaps before merging this, there should be a tag or branch created that is known to work for Crystal.

```
hlds_laser_publisher.cpp:156:75: warning: ‘std::shared_ptr<PublisherT> rclcpp::Node::create_publisher(const string&, const rmw_qos_profile_t&, std::shared_ptr<_Up>) [wit
h MessageT = sensor_msgs::msg::LaserScan_<std::allocator<void> >; AllocatorT = std::allocator<void>; PublisherT = rclcpp::Publisher<sensor_msgs::msg::LaserScan_<std::allocator<void> > >; std::__cxx11::string = std::__cxx11::basic_str
ing<char>; rmw_qos_profile_t = rmw_qos_profile_t]’ is deprecated: use create_publisher(const std::string &, const rclcpp::QoS &, ...) instead [-Wdeprecated-declarations]                                                                
     laser_pub = node->create_publisher<sensor_msgs::msg::LaserScan>("scan"); 

hlds_laser_publisher.cpp:167:30: warning: ‘void rclcpp::Publisher<MessageT, Alloc>::publish(const std::shared_ptr<const _Tp>&) [with MessageT = sensor_msgs::msg::LaserSc
an_<std::allocator<void> >; Alloc = std::allocator<void>]’ is deprecated: publishing an unique_ptr is prefered when using intra process communication. If using a shared_ptr, use publish(*msg). [-Wdeprecated-declarations]             
       laser_pub->publish(scan); 
```