### PR TITLE
Reduce scope to boost-system dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,7 +20,7 @@
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
-  <depend>boost</depend>
+  <depend>libboost-system-dev</depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
This package previously dependended on `boost`, which pulls in `libboost-all-dev` on Ubuntu. This is a very large dependency that pulls in hundreds of packages.

I have added `libboost-system-dev` here https://github.com/ros/rosdistro/pull/21834 to rosdep, so we can reduce the scope of this dependency and make it faster and smaller to install. It saves lots of time and space on a Raspberry Pi