### PR TITLE
[ros2] Enabling math constants for Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,12 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+if(MSVC)
+  add_compile_definitions(
+    _USE_MATH_DEFINES
+  )
+endif()
+
 ################################################################################
 # Find ament packages and libraries for ament and system dependencies
 ################################################################################


### PR DESCRIPTION
A fix to unblock Windows build.

* Define `_USE_MATH_DEFINES` to enable math constants usage. https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants