### PR TITLE
fix linker error in gcc 10.2

### DIFF
--- a/applications/lds_driver/Makefile
+++ b/applications/lds_driver/Makefile
@@ -12,11 +12,11 @@ SRCS			= lds_driver.cpp
 OBJS			= lds_driver.o
 LIB_DIRS	= -L/usr/lib/x86_64-linux-gnu
 INC_DIRS  = -I/usr/include
-LIBS      = -lboost_system
+LIBS      = -lboost_system -pthread
 TARGET 	  = lds_driver
 
 all : $(TARGET)
-	$(CXX) -o $(TARGET) $(OBJS) $(INC_DIRS) $(LIB_DIRS) $(LIBS) 
+	$(CXX) -o $(TARGET) $(OBJS) $(INC_DIRS) $(LIB_DIRS) $(LIBS)
  
 $(TARGET) :
 	$(CXX) -c $(SRCS) $(INC_DIRS) $(LIB_DIRS) $(LIBS) 


### PR DESCRIPTION
On Archlinux with GCC 10.2.0 I get the following error:
```
$ make
g++ -c lds_driver.cpp -I/usr/include -L/usr/lib/x86_64-linux-gnu -lboost_system 
g++ -o lds_driver lds_driver.o -I/usr/include -L/usr/lib/x86_64-linux-gnu -lboost_system 
/usr/bin/ld: lds_driver.o: undefined reference to symbol 'pthread_condattr_setclock@@GLIBC_2.3.3'
/usr/bin/ld: /usr/lib/libpthread.so.0: error adding symbols: DSO missing from command line
...
```
This commit adds `-pthread` and fixes this.