### PR TITLE
Fix LaserScan message timestamp

### DIFF
--- a/.github/workflows/ros-ci.yml
+++ b/.github/workflows/ros-ci.yml
@@ -3,13 +3,13 @@ name: ros-ci
 # Controls when the action will run. Triggers the workflow on push or pull request
 on:
   push:
-    branches: [ develop ]
+    branches: [ master ]
   pull_request:
-    branches: [ develop ]
+    branches: [ master ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  develop-ci:
+  master-ci:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # HLDS HLS-LFCD-LDS (LDS-01)
 <img src="http://emanual.robotis.com/assets/images/platform/turtlebot3/appendix_lds/lds.png" width="400">
 
-## ROS 1 Packages for LDS-01 Driver
-|develop|master|Kinetic + Ubuntu Xenial|Melodic + Ubuntu Bionic|Noetic + Ubuntu Focal|
-|:---:|:---:|:---:|:---:|:---:|
-|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=develop)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=master)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=kinetic-devel)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=melodic-devel)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=noetic-devel)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|
+[![kinetic-devel Status](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/workflows/kinetic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/tree/kinetic-devel)
 
-## ROS 2 Packages for LDS-01 Driver
-|ros2-devel|ros2|Dashing + Ubuntu Bionic|Eloquent + Ubuntu Bionic|Foxy + Ubuntu Foxy|
-|:---:|:---:|:---:|:---:|:---:|
-|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=ros2-devel)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=ros2)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=dashing-devel)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=eloquent-devel)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=foxy-devel)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|
+[![melodic-devel Status](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/workflows/melodic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/tree/melodic-devel)
+
+[![noetic-devel Status](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/workflows/noetic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/tree/noetic-devel)
+
+[![dashing-devel Status](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/workflows/dashing-devel/badge.svg)](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/tree/dashing-devel)
+
+[![foxy-devel Status](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/workflows/foxy-devel/badge.svg)](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/tree/foxy-devel)
 
 ## ROBOTIS e-Manual for TurtleBot3 and LDS-01
 - [ROBOTIS e-Manual for TurtleBot3 and LDS-01](http://turtlebot3.robotis.com/)

--- a/src/hlds_laser_publisher.cpp
+++ b/src/hlds_laser_publisher.cpp
@@ -84,6 +84,7 @@ void LFCDLaser::poll(sensor_msgs::LaserScan::Ptr scan)
         start_count = 0;
 
         // Now that entire start sequence has been found, read in the rest of the message
+        scan->header.stamp = ros::Time::now();
         got_scan = true;
 
         boost::asio::read(serial_,boost::asio::buffer(&raw_bytes[2], 2518));
@@ -168,7 +169,6 @@ int main(int argc, char **argv)
       sensor_msgs::LaserScan::Ptr scan(new sensor_msgs::LaserScan);
       scan->header.frame_id = frame_id;
       laser.poll(scan);
-      scan->header.stamp = ros::Time::now();
       rpms.data=laser.rpms;
       laser_pub.publish(scan);
       motor_pub.publish(rpms);

--- a/src/hlds_laser_segment_publisher.cpp
+++ b/src/hlds_laser_segment_publisher.cpp
@@ -76,6 +76,7 @@ void LFCDLaser::poll(sensor_msgs::LaserScan::Ptr scan)
     if(raw_bytes[0] == 0xFA)
     {
       // Now that entire start sequence has been found, read in the rest of the message
+      scan->header.stamp = ros::Time::now();
       got_scan = true;
       boost::asio::read(serial_,boost::asio::buffer(&raw_bytes[1], 41));
       
@@ -149,7 +150,6 @@ int main(int argc, char **argv)
     while (ros::ok())
     {
       laser.poll(scan);
-      scan->header.stamp = ros::Time::now();
       rpms.data=laser.rpms;
       laser_pub.publish(scan);
       motor_pub.publish(rpms);


### PR DESCRIPTION
According to the description of `sensor_msgs/LaserScan` [1], "the
timestamp in the header is the acquisition time of the first ray in
the scan".  In both `hlds_laser_publisher.cpp` and
`hlds_laser_segment_publisher.cpp`, however, the timestamp is taken
after the full message has been read, processed, and stored in the
`LaserScan` message, i.e. only after the last ray in the scan.
Consequently, with the lidar spinning at 5rps, the timestamp in the
message is about 0.2s later than it should be.

Acquire the timestamp right after the start sequence has been found to
make the message timestamp more accurate.

[1] https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/LaserScan.html