### PR TITLE
fix(package.xml): replace boost by libboost-dev dependency

### DIFF
--- a/.github/workflows/ros-ci.yml
+++ b/.github/workflows/ros-ci.yml
@@ -3,13 +3,13 @@ name: ros-ci
 # Controls when the action will run. Triggers the workflow on push or pull request
 on:
   push:
-    branches: [ develop ]
+    branches: [ master ]
   pull_request:
-    branches: [ develop ]
+    branches: [ master ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  develop-ci:
+  master-ci:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # HLDS HLS-LFCD-LDS (LDS-01)
 <img src="http://emanual.robotis.com/assets/images/platform/turtlebot3/appendix_lds/lds.png" width="400">
 
-## ROS 1 Packages for LDS-01 Driver
-|develop|master|Kinetic + Ubuntu Xenial|Melodic + Ubuntu Bionic|Noetic + Ubuntu Focal|
-|:---:|:---:|:---:|:---:|:---:|
-|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=develop)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=master)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=kinetic-devel)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=melodic-devel)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=noetic-devel)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|
+[![kinetic-devel Status](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/workflows/kinetic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/tree/kinetic-devel)
 
-## ROS 2 Packages for LDS-01 Driver
-|ros2-devel|ros2|Dashing + Ubuntu Bionic|Eloquent + Ubuntu Bionic|Foxy + Ubuntu Foxy|
-|:---:|:---:|:---:|:---:|:---:|
-|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=ros2-devel)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=ros2)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=dashing-devel)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=eloquent-devel)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|[![Build Status](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver.svg?branch=foxy-devel)](https://travis-ci.org/ROBOTIS-GIT/hls_lfcd_lds_driver)|
+[![melodic-devel Status](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/workflows/melodic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/tree/melodic-devel)
+
+[![noetic-devel Status](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/workflows/noetic-devel/badge.svg)](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/tree/noetic-devel)
+
+[![dashing-devel Status](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/workflows/dashing-devel/badge.svg)](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/tree/dashing-devel)
+
+[![foxy-devel Status](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/workflows/foxy-devel/badge.svg)](https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/tree/foxy-devel)
 
 ## ROBOTIS e-Manual for TurtleBot3 and LDS-01
 - [ROBOTIS e-Manual for TurtleBot3 and LDS-01](http://turtlebot3.robotis.com/)

--- a/package.xml
+++ b/package.xml
@@ -22,5 +22,5 @@
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
-  <depend>boost</depend>
+  <depend>libboost-dev</depend>
 </package>


### PR DESCRIPTION
On Ubuntu, the rosdep `boost` correspond to `libboost-all-dev`. The rosdep `libboost-dev` correspond to `libboost-dev`.

This repo only depends on `boost::asio` and `boost::array`. Both are already present on `libboost-dev`.
Hence, this prevents downloading multiple unnecessary dependencies