### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ include_directories(
 
 add_executable(hlds_laser_publisher	src/hlds_laser_publisher.cpp)
 target_link_libraries(hlds_laser_publisher ${Boost_LIBRARIES})
-ament_target_dependencies(hlds_laser_publisher
+target_link_libraries(hlds_laser_publisher PUBLIC
   rclcpp
   std_msgs
   sensor_msgs


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
