### PR TITLE
Replace boost::asio::io_service with boost::asio::io_context for boost 1.88 compatibility

### DIFF
--- a/applications/lds_driver/lds_driver.cpp
+++ b/applications/lds_driver/lds_driver.cpp
@@ -38,7 +38,7 @@
 
 namespace lds
 {
-LFCDLaser::LFCDLaser(const std::string & port, uint32_t baud_rate, boost::asio::io_service & io)
+LFCDLaser::LFCDLaser(const std::string & port, uint32_t baud_rate, boost::asio::io_context & io)
 : port_(port), baud_rate_(baud_rate), shutting_down_(false), serial_(io, port_)
 {
   serial_.set_option(boost::asio::serial_port_base::baud_rate(baud_rate_));
@@ -136,7 +136,7 @@ int main(int argc, char ** argv)
   uint16_t rpms;
   port = "/dev/ttyUSB0";
   baud_rate = 230400;
-  boost::asio::io_service io;
+  boost::asio::io_context io;
 
   try {
     lds::LFCDLaser laser(port, baud_rate, io);

--- a/applications/lds_driver/lds_driver.hpp
+++ b/applications/lds_driver/lds_driver.hpp
@@ -54,7 +54,7 @@ public:
   * @param io Boost ASIO IO Service to use when creating the serial port object
   */
 
-  LFCDLaser(const std::string & port, uint32_t baud_rate, boost::asio::io_service & io);
+  LFCDLaser(const std::string & port, uint32_t baud_rate, boost::asio::io_context & io);
   /**
   * @brief Default destructor
   */

--- a/applications/lds_driver/lds_driver.hpp
+++ b/applications/lds_driver/lds_driver.hpp
@@ -51,7 +51,7 @@ public:
     * @brief Constructs a new LFCDLaser attached to the given serial port
   * @param port The string for the serial port device to attempt to connect to, e.g. "/dev/ttyUSB0"
   * @param baud_rate The baud rate to open the serial port at.
-  * @param io Boost ASIO IO Service to use when creating the serial port object
+  * @param io Boost ASIO IO Context to use when creating the serial port object
   */
 
   LFCDLaser(const std::string & port, uint32_t baud_rate, boost::asio::io_context & io);

--- a/applications/lds_polar_graph/lds_polar_graph.hpp
+++ b/applications/lds_polar_graph/lds_polar_graph.hpp
@@ -69,7 +69,7 @@ private:
   qreal angular_max_;
   qreal radial_min_;
   qreal radial_max;
-  boost::asio::io_service io_;
+  boost::asio::io_context io_;
   std::string port_;
   uint32_t baud_rate_;
   bool shutting_down_;

--- a/include/hls_lfcd_lds_driver/hlds_laser_segment_publisher.hpp
+++ b/include/hls_lfcd_lds_driver/hlds_laser_segment_publisher.hpp
@@ -56,7 +56,7 @@ public:
   * @param baud_rate The baud rate to open the serial port at.
   * @param io Boost ASIO IO Service to use when creating the serial port object
   */
-  explicit LFCDLaser(boost::asio::io_service & io);
+  explicit LFCDLaser(boost::asio::io_context & io);
 
   /**
   * @brief Default destructor

--- a/include/hls_lfcd_lds_driver/hlds_laser_segment_publisher.hpp
+++ b/include/hls_lfcd_lds_driver/hlds_laser_segment_publisher.hpp
@@ -54,7 +54,7 @@ public:
   * @brief Constructs a new LFCDLaser attached to the given serial port
   * @param port The string for the serial port device to attempt to connect to, e.g. "/dev/ttyUSB0"
   * @param baud_rate The baud rate to open the serial port at.
-  * @param io Boost ASIO IO Service to use when creating the serial port object
+  * @param io Boost ASIO IO Context to use when creating the serial port object
   */
   explicit LFCDLaser(boost::asio::io_context & io);
 

--- a/include/hls_lfcd_lds_driver/lfcd_laser.hpp
+++ b/include/hls_lfcd_lds_driver/lfcd_laser.hpp
@@ -54,7 +54,7 @@ public:
   * @param baud_rate The baud rate to open the serial port at.
   * @param io Boost ASIO IO Service to use when creating the serial port object
   */
-  LFCDLaser(const std::string & port, uint32_t baud_rate, boost::asio::io_service & io);
+  LFCDLaser(const std::string & port, uint32_t baud_rate, boost::asio::io_context & io);
 
   /**
   * @brief Default destructor

--- a/include/hls_lfcd_lds_driver/lfcd_laser.hpp
+++ b/include/hls_lfcd_lds_driver/lfcd_laser.hpp
@@ -52,7 +52,7 @@ public:
   * @brief Constructs a new LFCDLaser attached to the given serial port
   * @param port The string for the serial port device to attempt to connect to, e.g. "/dev/ttyUSB0"
   * @param baud_rate The baud rate to open the serial port at.
-  * @param io Boost ASIO IO Service to use when creating the serial port object
+  * @param io Boost ASIO IO Context to use when creating the serial port object
   */
   LFCDLaser(const std::string & port, uint32_t baud_rate, boost::asio::io_context & io);
 

--- a/src/hlds_laser_publisher.cpp
+++ b/src/hlds_laser_publisher.cpp
@@ -39,7 +39,7 @@
 
 namespace hls_lfcd_lds
 {
-LFCDLaser::LFCDLaser(const std::string & port, uint32_t baud_rate, boost::asio::io_service & io)
+LFCDLaser::LFCDLaser(const std::string & port, uint32_t baud_rate, boost::asio::io_context & io)
 : port_(port), baud_rate_(baud_rate), shutting_down_(false), serial_(io, port_)
 {
   serial_.set_option(boost::asio::serial_port_base::baud_rate(baud_rate_));
@@ -127,7 +127,7 @@ int main(int argc, char ** argv)
 
   auto node = rclcpp::Node::make_shared("hlds_laser_publisher");
   rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr laser_pub;
-  boost::asio::io_service io;
+  boost::asio::io_context io;
 
   std::string port;
   std::string frame_id;

--- a/src/hlds_laser_segment_publisher.cpp
+++ b/src/hlds_laser_segment_publisher.cpp
@@ -41,7 +41,7 @@
 
 namespace hls_lfcd_lds
 {
-LFCDLaser::LFCDLaser(boost::asio::io_service & io)
+LFCDLaser::LFCDLaser(boost::asio::io_context & io)
 : serial_(io),
   shutting_down_(false)
 {
@@ -132,7 +132,7 @@ int main(int argc, char * argv[])
 {
   ros::init(argc, argv, "hlds_laser_segment_publisher");
 
-  boost::asio::io_service io;
+  boost::asio::io_context io;
   hls_lfcd_lds::LFCDLaser laser(io);
 
   while (ros::ok()) {


### PR DESCRIPTION
`boost::asio::io_service` is just a deprecated typedef of `boost::asio::io_context`, at least since boost 1.67 (see https://github.com/boostorg/asio/blob/boost-1.67.0/include/boost/asio/io_service.hpp#L27), the boost version used in apt in Ubuntu 20.04 (see https://repology.org/project/boost/versions)

The `boost::asio::io_service` typedef was removed in Boost 1.88, and this if fixed in this PR by replacing `boost::asio::io_service` with `boost::asio::io_context`, that is perfectly back-compatible as `boost::asio::io_service` was just a typedef for   `boost::asio::io_context`.